### PR TITLE
Fix toggle play/pause functionality by aligning status values with MusicPlayer capability standard

### DIFF
--- a/volumio_integration_driver.groovy
+++ b/volumio_integration_driver.groovy
@@ -4,6 +4,9 @@ Author: Flint IronStag
 https://github.com/jbobthegreat/hubitat_volumio_integration
 
 Revision History
+1.07 11.06.2025 - Fixed status attribute values to match Hubitat MusicPlayer capability standard
+				  (Changed "play"/"pause"/"stop" to "playing"/"paused"/"stopped")
+				  This fixes Rule Machine's "toggle play/pause" action for button controllers
 1.06 03.01.2024 - Updated random() and repeat() methods to either toggle or set explicitly
 				  Added ability to play Pandora channels to Play Track command
 				  Bug fixes
@@ -207,6 +210,14 @@ def parseState(respData) {
     for(int i in 0..(attributes.size-1)) {
         def oldValue = device.currentValue("${attributes[i]}")
         def newValue = respData."${respDataNames[i]}"
+
+        // Translate Volumio status values to Hubitat MusicPlayer standard values
+        if (attributes[i] == "status" && newValue) {
+            if (newValue == "play") { newValue = "playing" }
+            else if (newValue == "pause") { newValue = "paused" }
+            else if (newValue == "stop") { newValue = "stopped" }
+        }
+
         if ("${newValue}") {  //checks for null data. Uses string value because "mute" JSON data is boolean and returns false when unmuted
             if ("${newValue}" != "${oldValue}") {  //Uses string value because "mute" attribute data is string, but JSON data is boolean
                 ( updateAttribute(attributes[i], newValue) )


### PR DESCRIPTION
## Problem
Rule Machine's "toggle play/pause" action was not working correctly for button controllers and automations. It would only ever call `play()` instead of properly toggling between play and pause states.

## Root Cause
The driver was reporting status attribute values directly from Volumio's API (`"play"`, `"pause"`, `"stop"`), but Hubitat's MusicPlayer capability standard expects different values (`"playing"`, `"paused"`, `"stopped"`). This mismatch caused Rule Machine's built-in toggle logic to fail when checking the device's current playback state.

## Solution
Added translation logic in the `parseState()` function to convert Volumio's status values to Hubitat's MusicPlayer capability standard values:
- `"play"` → `"playing"`
- `"pause"` → `"paused"`
- `"stop"` → `"stopped"`

## Testing
- Verified Rule Machine's "toggle play/pause" action now correctly toggles between play and pause
- Confirmed button controllers can reliably toggle playback state
- Tested that status updates correctly reflect changes made directly in Volumio (via push notifications)

## Changes
- Modified `parseState()` function to translate status values (lines 212-217)
- Updated revision history to version 1.07
  - Modified `parseState()` function to translate status values (lines 212-217)
  - Updated revision history to version 1.07